### PR TITLE
Add setup script for macOS/Linux users + Gitpod config

### DIFF
--- a/.devcontainer/flutter.bashrc
+++ b/.devcontainer/flutter.bashrc
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export PATH=/home/gitpod/flutter/bin:$PATH

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM gitpod/workspace-full
+
+### NOTE FROM ANDREI JIROH - START ###
+# TL;DR: 1) run "docker build --file .gitpod.Dockerfile .devcontainer" when reproducing this image, and 2) keep Flutter code up-to-date with Flutter releases as much as possible
+# - If you reproducing the build of this Dockerfile for Gitpod, please use the .devcontainer directory as your context while $PWD/.gitpod.Dockerfile as the file flag when doing docker build locally.
+# - Update Flutter code to be compartible with latest release as possible. (Beware of major releases!) If in the future HydraLite wants its Flutter code to be also works 
+# for desktop and web, update this Dockerfile to include commands found in https://flutter.dev/docs/get-started/install/linux#linux-setup and https://flutter.dev/docs/get-started/web
+
+### NOTE FROM ANDREI JIROH - END ###
+
+USER gitpod
+
+# Make 
+
+### Flutter ###
+# Note that you cannot emulate Android apps yet because of KVM requirement, but nested birtualization is unsupported in GKE currently
+# See Gitpod issue at https://github.com/gitpod-io/gitpod/issues/1273 and also in Google Issue Tracker in general at https://issuetracker.google.com/issues/110507927?pli=1
+ENV FLUTTER_VERSION=2.0.5 FLUTTER_RELEASE_CHANNEL=stable
+RUN sudo apt install libglu1-mesa -y \
+    && wget -qO- https://storage.googleapis.com/flutter_infra_release/releases/${FLUTTER_RELEASE_CHANNEL}/linux/flutter_linux_${FLUTTER_VERSION}-${FLUTTER_RELEASE_CHANNEL}.tar.xz | tar -xfv -C /home/gitpod \
+    && /home/gitpod/flutter/bin/flutter 
+    # TODO: Add Linux setup for desktop if needed. Also install Chrome for web
+
+# Note from @ajhalili2006: $PROJECT_ROOT/.devcontainer/flutter.bashrc
+COPY flutter.bashrc /home/gitpod/.bashrc/40-flutter

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+  context: .devcontainer
+tasks:
+- before: IS_GITPOD_PREBUILD=1 ./setup.sh

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ Hydralite is a system that steers away from typical scrum methodology and adopts
 
 ## Getting Started
 
-Run `setup` (in the root directory) in a new cmd session (only supports command prompt for now)
+Run `setup.cmd` in Windows Command Prompt or `setup.sh` in an macOS/Linux shell at the root directory after cloning.
 Once the setup command has been run based on your shell provider, run `yarn dev` in the root directory to start the api and web servers.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Install deps first
+yarn
+
+if [[ $IS_GITPOD_PREBUILD != "1" ]]; then
+  # Run 'yarn setup' if not running this script as part of prebuilds in Gitpod
+  yarn setup
+fi


### PR DESCRIPTION
## About This Issue

* Add `setup` script for macOS and Linux users
* Add Gitpod configuration + custom Dockerfile for the toolchains this project requires

## Caveats

* Since Gitpod.io (the SaaS version of [Gitpod](https://github.com/gitpod-io/gitpod)) is hosted on GCP, its Kubernetes offering (called Google Kubernetes Engine), nested virtualization isn't supported for now. See https://github.com/gitpod-io/gitpod/issues/1273 and https://issuetracker.google.com/issues/110507927?pli=1 for details.

## Notes from PR Author

* While there's an `.devcontainer` directory, that was only used to store an custom bashrc file for Flutter which will be used as Docker build context during Gitpod prebuilds.