### PR TITLE
Fix apt install errors + add VS Code extensions for Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,26 +1,45 @@
 # syntax=docker/dockerfile:1
 FROM gitpod/workspace-full
+# TODO: Possibly build WS image from scratch using gitpod/workspace-base to optmize image size and boot times.
+# If gone to that path, we'll only install Python 3.x through pyenv, Node.js 14.x through nvm and Cargo/Rust.
 
 ### NOTE FROM ANDREI JIROH - START ###
-# TL;DR: 1) run "docker build --file .gitpod.Dockerfile .devcontainer" when reproducing this image, and 2) keep Flutter code up-to-date with Flutter releases as much as possible
-# - If you reproducing the build of this Dockerfile for Gitpod, please use the .devcontainer directory as your context while $PWD/.gitpod.Dockerfile as the file flag when doing docker build locally.
+# TL;DR: 1) run "docker build --tag eu.gcr.io/gitpodify/hydralite:dev --file .gitpod.Dockerfile .devcontainer" when reproducing this image, and 2) keep Flutter code up-to-date with Flutter releases as much as possible
+# - If you reproducing the build of this Dockerfile for Gitpod, please use the .devcontainer directory as your context while $PWD/.gitpod.Dockerfile as the file flag when doing docker build locally. Enabling BuildKit at client or deamon side or setting up Buildx and using "docker buildx build" instead of the "docker build" command above are welcome.
+# - After confirming that the image build succeeds, fire up an seperate Gitpod workspace to check if its working, especially if your edited the .gitpod.yml file.
 # - Update Flutter code to be compartible with latest release as possible. (Beware of major releases!) If in the future HydraLite wants its Flutter code to be also works 
 # for desktop and web, update this Dockerfile to include commands found in https://flutter.dev/docs/get-started/install/linux#linux-setup and https://flutter.dev/docs/get-started/web
-
+# - Actually there's an offical workspace image with Dart installed (https://github.com/gitpod-io/workspace-images/blob/master/dart/Dockerfile), but I preferred to use the one that included in Flutter
 ### NOTE FROM ANDREI JIROH - END ###
 
 USER gitpod
 
-# Make 
+# Make sure we have latest repositories' cache first, so we don't hit that 404 Not Fund errors when doing "apt install"
+RUN sudo apt update
 
 ### Flutter ###
 # Note that you cannot emulate Android apps yet because of KVM requirement, but nested birtualization is unsupported in GKE currently
 # See Gitpod issue at https://github.com/gitpod-io/gitpod/issues/1273 and also in Google Issue Tracker in general at https://issuetracker.google.com/issues/110507927?pli=1
+
+# Update the FLUTTER_VERSION variable below to the latest major.minor.patch release and update Flutter code to be compartible with that version as per the official docs.
 ENV FLUTTER_VERSION=2.0.5 FLUTTER_RELEASE_CHANNEL=stable
+# Dependencies for Dart itself, even we used the one included in Flutter, just in case you prefer not to use Flutter
+RUN sudo apt install libkrb5-dev gcc make build-essential -y
+# Main Flutter install
 RUN sudo apt install libglu1-mesa -y \
-    && wget -qO- https://storage.googleapis.com/flutter_infra_release/releases/${FLUTTER_RELEASE_CHANNEL}/linux/flutter_linux_${FLUTTER_VERSION}-${FLUTTER_RELEASE_CHANNEL}.tar.xz | tar -xfv -C /home/gitpod \
-    && /home/gitpod/flutter/bin/flutter 
+    && wget -qO- https://storage.googleapis.com/flutter_infra_release/releases/${FLUTTER_RELEASE_CHANNEL}/linux/flutter_linux_${FLUTTER_VERSION}-${FLUTTER_RELEASE_CHANNEL}.tar.xz | tar -xJv -C /home/gitpod \
+    # Note from @ajhalili2006: precaching platform-specific dev binaries are optionally btw, but include them to speed up development time
+    # we'll pull artifacts for Android and iOS + universal artifacts for any dev platform
+    # For desktop development, add linux, windows and macos flags. For the web, add web flag.
+    && /home/gitpod/flutter/bin/flutter precache --android --ios --universal -v
     # TODO: Add Linux setup for desktop if needed. Also install Chrome for web
 
 # Note from @ajhalili2006: $PROJECT_ROOT/.devcontainer/flutter.bashrc
-COPY flutter.bashrc /home/gitpod/.bashrc/40-flutter
+COPY flutter.bashrc /home/gitpod/.bashrc.d/40-flutter
+
+### Cleanup ###
+RUN sudo apt-get clean -y && \
+   sudo rm -rfv /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /tmp/* \
+   /var/tmp/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,24 @@
 image:
   file: .gitpod.Dockerfile
   context: .devcontainer
+
+# See https://www.gitpod.io/docs/config-start-tasks to configure tasks in Gitpod
+# Before and init tasks are better run in tandem during prebuilds, which you can learn more at https://www.gitpod.io/docs/prebuilds.
 tasks:
-- before: IS_GITPOD_PREBUILD=1 ./setup.sh
+  # Install Yarn dependencies during prebuilds first with IS_GITPOD_PREBUILD set to 1 to ensure we don't hit that "api/.env Not found" error. Possibly implement Docker Compose and installing crates for the cli directory soon
+  - init: IS_GITPOD_PREBUILD=1 ./setup.sh
+
+vscode:
+  # Open this repo inside Gitpod to upload *.vsix files that's not found on Open VSIX or if you built an opensource VS Code extension yourself.
+  # WARNING: DO NOT UPLOAD EVERYTHING from Microsoft VS Code Extensions Store for legal reasons. See VS Code terms of use for details.
+  extensions:
+    # Prettier VS Code extension
+    - esbenp.prettier-vscode
+    # VS Code intgration for ShellCheck so see the docs on how to ignore errors, among other things
+    - timonwong.shellcheck
+    # VS Code icon theme Fireship.io uses (Disclaimer: @ajhalili2006 is an fan of Fireship)
+    - vscode-icons-team.vscode-icons
+    # GitLens for seeing file annonations and more
+    - eamodio.gitlens
+    # Wait a sec, Docker stuff?
+    - ms-azuretools.vscode-docker

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,3 +22,20 @@ vscode:
     - eamodio.gitlens
     # Wait a sec, Docker stuff?
     - ms-azuretools.vscode-docker
+    
+ github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false

--- a/README.md
+++ b/README.md
@@ -24,5 +24,16 @@ Hydralite is a system that steers away from typical scrum methodology and adopts
 
 ## Getting Started
 
-Run `setup.cmd` in Windows Command Prompt or `setup.sh` in an macOS/Linux shell at the root directory after cloning.
-Once the setup command has been run based on your shell provider, run `yarn dev` in the root directory to start the api and web servers.
+### Local Development
+
+* Run `setup.cmd` in Windows Command Prompt or `setup.sh` in an macOS/Linux shell at the root directory after cloning.
+* Once the setup command has been run based on your shell provider, run `yarn dev` in the root directory to start the API and web servers.
+
+### In Gitpod
+
+* [Open this repo in Gitpod.io](https://gitpod.io/#github.com/hydralite/hydralite). Sign in using your GItHub account if needed.
+* Once the API and web servers are up in development mode, enjoy hacking/coding.
+
+While Node.js/Python (web, API, automation and landing page) and Rust (CLI) development will work flawlessly in Gitpod, FLutter/Dart
+development may work but nested virtualization for Android emulators in case of mobile app development isn't supprted in
+Google Kubernetes Engine (where Gitpod.io hosted).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Hydralite is a system that steers away from typical scrum methodology and adopts
 
 ### Local Development
 
+Make sure you installed Node.js (web, API, landing, Discord bot), Python (automation), Rust (CLI) and/or Flutter + Dart (mobile
+client app) before start hacking/contributing within your local machine, especially if you use [code-server](https://github.com/cdr/code-server)
+within an Dockerized development environment or in an VPS. Our setup script will only install Yarn for you to get started with the
+webapp and GraphQL API develpment.
+
 * Run `setup.cmd` in Windows Command Prompt or `setup.sh` in an macOS/Linux shell at the root directory after cloning.
 * Once the setup command has been run based on your shell provider, run `yarn dev` in the root directory to start the API and web servers.
 
@@ -34,6 +39,6 @@ Hydralite is a system that steers away from typical scrum methodology and adopts
 * [Open this repo in Gitpod.io](https://gitpod.io/#github.com/hydralite/hydralite). Sign in using your GItHub account if needed.
 * Once the API and web servers are up in development mode, enjoy hacking/coding.
 
-While Node.js/Python (web, API, automation and landing page) and Rust (CLI) development will work flawlessly in Gitpod, FLutter/Dart
+While Node.js/Python (web, API, automation and landing page) and Rust (CLI) development will work flawlessly in Gitpod, Flutter/Dart
 development may work but nested virtualization for Android emulators in case of mobile app development isn't supprted in
 Google Kubernetes Engine (where Gitpod.io hosted).

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ checkIfYarnInstalled() {
   fi
 }
 
-# Terminal colors, copied from https://github.com/railwayapp
+# Terminal colors, copied from https://github.com/railwayapp/cli/blob/master/install.sh#L60-L79
 useColor() {
   # Only use colors if connected to a terminal
   if [ -t 1 ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,71 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
-# Install deps first
-yarn
+checkIfYarnInstalled() {
+  YARNPKG_PATH=$(which yarn)
 
-if [[ $IS_GITPOD_PREBUILD != "1" ]]; then
-  # Run 'yarn setup' if not running this script as part of prebuilds in Gitpod
-  yarn setup
-fi
+  if [[ $YARNPKG_PATH == "" ]]; then
+    warn "Yarn isn't installed, installing with npmjs..."
+    npm i -g yarn
+  fi
+}
+
+# Terminal colors, copied from https://github.com/railwayapp
+useColor() {
+  # Only use colors if connected to a terminal
+  if [ -t 1 ]; then
+    RED=$(printf '\033[31m')
+    GREEN=$(printf '\033[32m')
+    YELLOW=$(printf '\033[33m')
+    BLUE=$(printf '\033[34m')
+    MAGENTA=$(printf '\033[35m')
+    BOLD=$(printf '\033[1m')
+    RESET=$(printf '\033[m')
+  else
+    RED=""
+    GREEN=""
+    YELLOW=""
+    BLUE=""
+    MAGENTA=""
+    BOLD=""
+    RESET=""
+  fi
+}
+
+# Source: https://github.com/ajhalili2006/dotfiles/blob/main/bootstrap#L38-L57
+echoStageName() {
+    echo "${BOLD}----> $* ${RESET}"
+}
+echoStageNameAdd() {
+    echo "${BOLD}      $* ${RESET}"
+}
+warn() {
+    echo "${YELLOW}warning: $* ${RESET}"
+}
+error() {
+    # this will be long, so I must do "&& exit 1" manually
+    echo "${RED}error: $* ${RESET}"
+}
+success() {
+    echo "${GREEN}success: $* ${RESET}"
+}
+
+main() {
+  useColor
+
+  # Install Yarn if not yet installed
+  checkIfYarnInstalled
+
+  # Install deps first
+  yarn
+
+  if [[ $IS_GITPOD_PREBUILD != "1" ]]; then
+    # Run 'yarn setup' if not running this script as part of prebuilds in Gitpod
+    yarn setup
+  fi
+
+  # TODO: Check if Cargo and Rust installed and install deps for cli/*
+}
+
+# We wrapped the main logic as an function to make things nicer.
+main


### PR DESCRIPTION
## Summary of changes

* Wrapping the main logic around the main function for `setup.sh`
* Seed some VS code extensions available from [Open VSX](https://open-vsx.org). Proceed at your own risk if sideloading an extension from Visual Studio Marketplace. [As per the Gitpod docs](https://www.gitpod.io/docs/vscode-extensions#where-do-i-find-extensions), _Microsoft prohibits the direct use of their marketplace by any non-Microsoft software, even though most extensions are actually open source and not developed or maintained by Microsoft_.
* Finally adding fixes to the `apt install` errors by doing `sudo apt install` first.
* Update documentation for development stuff in README.

## Next Steps for Maintainers

* Follow the instructions to [enable prebuilds for HydraLite](https://www.gitpod.io/docs/prebuilds#on-github).

## Next Steps for the Contributor

* Create a [deploy-code-server](https://github.com/cdr/deploy-code-server)-like GitHub template for Hydralite.