### PR TITLE
Made Development setup for Databases in api simpler

### DIFF
--- a/api/default.env
+++ b/api/default.env
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:password@localhost:5432
+REDIS_PASSWORD=password

--- a/api/docker/hydralite-api/docker-compose.yml
+++ b/api/docker/hydralite-api/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"  # optional since v1.27.0
+services:
+  postgresql:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment: 
+        POSTGRES_PASSWORD: "password"
+  redis:
+    image: redis
+    command: redis-server --requirepass password
+    ports:
+        - "6379:6379"

--- a/api/package.json
+++ b/api/package.json
@@ -8,6 +8,10 @@
     "prisma:push": "prisma db push",
     "prisma:generate": "prisma generate",
     "prisma:format": "prisma format",
+
+    "db:start": "cd docker/hydralite-api/ & docker compose up -d",
+    "db:stop": "cd docker/hydralite-api/ & docker compose down",
+
     "build": "tsc && tsc-alias",
     "start": "node dist/index.js",
     "setup": "node setup.js && npm run prisma:push",


### PR DESCRIPTION
use `npm run db:start` to start redis and postgresql in docker containers
use `npm run db:stop` to stopredis and postgresql in docker containers

this needs docker installed but these are just optional commands