### PR TITLE
fix(wcag): adjust `muted-3` color to pass wcag

### DIFF
--- a/landing/styles/globals.css
+++ b/landing/styles/globals.css
@@ -22,7 +22,7 @@ BREAKPOINTS:
   --muted-2: #e5e5e5;
   --muted-2-inverted: var(--primary);
 
-  --muted-3: #8098b4;
+  --muted-3: #6582A4;
 
   --muted-4: #e2e8f0;
   --muted-4-inverted: var(--primary);


### PR DESCRIPTION
WCAG score from 2.81 score to 3.76.

Before:
![image](https://user-images.githubusercontent.com/43641633/127517972-32b468ec-ca16-44b6-915b-5b61fe83ba15.png)


After:
![image](https://user-images.githubusercontent.com/43641633/127517892-04c77f02-11c4-457f-b429-c038967bb027.png)
