### PR TITLE
style(web): add redesign colours to Tailwind config

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -7,21 +7,46 @@ module.exports = {
   ],
   darkMode: false,
   theme: {
-    colors: {
-      transparent: "transparent",
-      dark: {
-        bg: "#242832",
-        fg: "#ffffff",
-        textMuted: "#E5E5E5",
-        bgMuted1: "#1C212D",
-        bgMuted2: "#272D3D",
-        bgMuted3: "#1C212D75",
-        bgMuted4: "#292F40",
-        border1: "#2B2F39",
-        color: {
-          accent: "#5D6BFF",
-          yellow: "#EFA119",
+    extend: {
+      colors: {
+        /* BEGIN legacy colors */
+        // TODO: replace all instances of these with iris/acrylic
+        transparent: "transparent",
+        dark: {
+          bg: "#242832",
+          fg: "#ffffff",
+          textMuted: "#E5E5E5",
+          bgMuted1: "#1C212D",
+          bgMuted2: "#272D3D",
+          bgMuted3: "#1C212D75",
+          bgMuted4: "#292F40",
+          border1: "#2B2F39",
+          color: {
+            accent: "#5D6BFF",
+            yellow: "#EFA119",
+          },
         },
+        /* END legacy colors */
+        iris: {
+          10: "#F0F2FF",
+          20: "#BDC2FF",
+          30: "#7581FF",
+          40: "#5261FF",
+          DEFAULT: "#5261FF",
+          50: "#424FD6",
+          60: "#2E39AD",
+          70: "#1C2582"
+        },
+        acrylic: {
+          10: "#F7F7F8",
+          20: "#DBDBE1",
+          30: "#C1C2CD",
+          40: "#A5A7B6",
+          50: "#76788F",
+          60: "#5E6073",
+          70: "#22232A",
+          80: "#0B0C0E"
+        }
       },
     },
     variants: {},


### PR DESCRIPTION
This pull request sets up the new Iris and Acrylic colour scales for use on the web project. We expect to eventually phase out the currently used colours (marked as legacy in tailwind.config.js), at which point those colours should be removed from the config file.